### PR TITLE
Support all babel transform options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Using the high-level `getPlugin` API:
 ```ts
 import type {Codemod} from '@nick.heiner/jscodemod';
 const codemod: Codemod = {
-  // Whatever presets are needed to parse your code.
-  presets: ['@babel/preset-react', '@babel/preset-typescript', '@babel/preset-env']
+  // Whatever babel configuration is needed to parse or transform your code.
+  babelTransformOptions: {
+    presets: ['@babel/preset-react', '@babel/preset-typescript', '@babel/preset-env']
+  },
 
   // The transformation you'd like to do in the codemod.
   getPlugin({source, fileName}) {

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -49,7 +49,6 @@ Sometimes, you might not want to make any changes, but do want to use Babel's po
 
 ```js
 module.exports = {
-    presets: [],
     getPlugin({ willNotifyOnAstChange, setMetaResult }) {
         // Because we don't plan to modify the AST, call this function, then never call astDidChange(). That way, jscodemod
         // won't change the file.

--- a/fixtures/arrow-function-inline-return/codemod/index.ts
+++ b/fixtures/arrow-function-inline-return/codemod/index.ts
@@ -40,7 +40,9 @@ const codemod: Codemod = {
         }
       });
   },
-  presets: ['@babel/preset-react', '@babel/preset-typescript', '@babel/preset-env']
+  babelTransformOptions: {
+    presets: ['@babel/preset-react', '@babel/preset-typescript', '@babel/preset-env']
+  }
 };
 
 export default codemod;

--- a/fixtures/return-meta-from-plugin/codemod.js
+++ b/fixtures/return-meta-from-plugin/codemod.js
@@ -7,7 +7,6 @@ const silenceableLog = (...args) => {
 }
 
 module.exports = {
-  presets: [],
   getPlugin({willNotifyOnAstChange, setMetaResult}) {
     willNotifyOnAstChange();
     return ({}) => ({

--- a/src/run-codemod-on-file.ts
+++ b/src/run-codemod-on-file.ts
@@ -138,7 +138,7 @@ export default async function runCodemodOnFile(
       parse(source: string, opts: Record<string, unknown>) {
         const babelOpts = {
           ...getBabelOpts(),
-          ..._.pick(codemod, 'presets'),
+          ..._.pick(codemod, 'babelTransformOptions'),
           // There are options that are recognized by recast but not babel. Babel errors when they're passed. To avoid
           // this, we'll omit them.
           ..._.omit(
@@ -152,7 +152,8 @@ export default async function runCodemodOnFile(
            * https://github.com/benjamn/recast/issues/834
            */
           parserOpts: {
-            tokens: true
+            tokens: true,
+            ..._.pick(codemod, 'babelTransformOptions.parserOpts')
           }
         };
         log.trace({babelOpts});

--- a/src/run-codemod-on-file.ts
+++ b/src/run-codemod-on-file.ts
@@ -166,7 +166,7 @@ export default async function runCodemodOnFile(
       ast = recast.parse(fileContentsForRecast, {parser});
     } catch (e) {
       e.phase = 'recast.parse using the settings you passed';
-      e.suggestion = "Check that you passed the right babel preset in the codemod's `presets` field.";
+      e.suggestion = "Check that you passed the right babel configuration in the codemod's `babelTransformOptions` field.";
       throw e;
     }
 

--- a/src/run-codemod-on-file.ts
+++ b/src/run-codemod-on-file.ts
@@ -166,7 +166,8 @@ export default async function runCodemodOnFile(
       ast = recast.parse(fileContentsForRecast, {parser});
     } catch (e) {
       e.phase = 'recast.parse using the settings you passed';
-      e.suggestion = "Check that you passed the right babel configuration in the codemod's `babelTransformOptions` field.";
+      e.suggestion =
+        "Check that you passed the right babel configuration in the codemod's `babelTransformOptions` field.";
       throw e;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export type Codemod<ParsedArgs = unknown, TransformResultMeta = unknown> = {
     source: string;
   } & BaseCodemodArgs<ParsedArgs>): CodemodResult<TransformResultMeta> | Promise<CodemodResult<TransformResultMeta>>;
 
-  presets?: never;
+  babelTransformOptions?: never;
   getPlugin?: never;
 } | {
   transform?: never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,9 +104,10 @@ export type Codemod<ParsedArgs = unknown, TransformResultMeta = unknown> = {
   transform?: never;
 
   /**
-   * The set of babel presets needed to compile your code, like `@babel/preset-env`.
+   * The set of babel transform options needed to compile your code, such as `presets`. More details can be found
+   * [in the Babel documentation](https://babeljs.io/docs/en/options).
    */
-  presets: TransformOptions['presets'];
+  babelTransformOptions: TransformOptions;
 
   /**
    * Return a plugin that will be used to codemod your code.


### PR DESCRIPTION
## Reason for change

The top-level `presets` API is inherently limiting, as only Babel presets can be used to provide a babel configuration for the plugin. Ideally all the babel options would be supported, as is called out in #28 .

## Change

Modify API to have `babelTransformOptions` be the entrypoint for babel options that can be overridden, and that is merged into the options created by `getBabelOpts`.

### Note

Because of some internal dependencies, I was not able to verify everything locally (out of the box, 22 of 31 unit tests fail locally). My changes do not cause any additional tests to fail, and it passes typecheck, so it _should_ be okay.

I'm trying to figure out how to do a simple unit test to verify custom options output, but there are a few layers to peel back there. Advice would be welcome.