### PR TITLE
Fix issue with TS root dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "find-up": "5.0.0",
     "globby": "11.0.1",
     "ignore": "5.1.8",
+    "jsonc-parser": "3.0.0",
     "load-json-file": "6.2.0",
     "lodash": "4.17.20",
     "loud-rejection": "2.2.0",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -12,8 +12,6 @@ import {CodemodMetaResult} from './run-codemod-on-file';
 import PrettyError from 'pretty-error';
 import ansiColors from 'ansi-colors';
 
-const tsOnlyNote = '(Only applicable if your codemod is written in TypeScript)';
-
 // Passing paths as file globs that start with `.` doesn't work.
 // https://github.com/sindresorhus/globby/issues/168
 
@@ -59,16 +57,16 @@ const {argv} = yargs
     // TODO: allow arbitrary TS arg passthrough at your own risk.
     tsconfig: {
       type: 'string',
-      describe: `${tsOnlyNote} path to the tsconfig.json`
+      describe: 'path to the tsconfig.json'
     },
     // I'm going to skip adding tests for this for now, because I'm not sure it's actually necessary.
     tsOutDir: {
       type: 'string',
-      describe: `${tsOnlyNote} directory in which to compile your codemod to. Defaults to a temporary directory.`
+      describe: 'directory in which to compile your codemod to. Defaults to a temporary directory.'
     },
     tsc: {
       type: 'string',
-      describe: `${tsOnlyNote} path to a "tsc" executable to compile your codemod. ` +
+      describe: 'path to a "tsc" executable to compile your codemod. ' +
        'Defaults to looking for a "tsc" bin accessible from the current working directory.'
     },
     dry: {
@@ -109,7 +107,7 @@ const {argv} = yargs
     }
   })
   .group(['codemod', 'dry', 'resetDirtyInputFiles', 'inputFileList'], 'Primary')
-  .group(['tsconfig', 'tsOutDir', 'tsc'], 'TypeScript')
+  .group(['tsconfig', 'tsOutDir', 'tsc'], 'TypeScript (only applicable if your codemod is written in TypeScript)')
   .group(['jsonOutput', 'porcelain'], 'Rarely Useful')
   .check(argv => {
     const log = getLogger(_.pick(argv, 'jsonOutput', 'porcelain'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4848,6 +4848,11 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonc-parser@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+
 jsx-ast-utils@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz#1114a4c1209481db06c690c2b4f488cc665f657e"


### PR DESCRIPTION
For TS codemods, the flow is:

1. Create a temp dir.
2. Run `tsc` to convert the TS codemod to JS.
3. Require that compiled JS file.

Depending on the user's setup, it was easy to have a mismatch where jscodemod wouldn't know where to find the compiled JS file. This fixes that issue.